### PR TITLE
fix(settings): correct extraKnownMarketplaces format + update project docs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,8 +1,10 @@
 {
-  "extraKnownMarketplaces": [
-    {
-      "name": "debussy",
-      "url": "https://raw.githubusercontent.com/jcbianic/debussy/main/.claude-plugin/marketplace.json"
+  "extraKnownMarketplaces": {
+    "debussy": {
+      "source": {
+        "source": "github",
+        "repo": "jcbianic/debussy"
+      }
     }
-  ]
+  }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,7 @@ See `specs/intents.md` for the full list. The order matters:
 0. **000 — Project Bootstrap**: scaffold Nuxt 4 app, verify foundation
 1. **001 — IIKit Phase Model**: workflow data model and phase-aware UI
 2. **002 — Workflow Runner**: execute IIKit phases via subprocess
-3. **003 — Artifact Viewer**: browse IIKit-produced files
-4. **004 — Worktree Isolation**: isolate concurrent workflows via git worktrees
-5. **005 — Cost Monitoring**: token usage and cost tracking
+3. **003 — Review UI**: item-by-item interactive review with structured output
+4. **004 — Artifact Viewer**: browse and validate IIKit-produced files
+5. **005 — Worktree Isolation**: isolate concurrent workflows via git worktrees
+6. **006 — Cost Monitoring**: token usage and cost tracking

--- a/INTENT.md
+++ b/INTENT.md
@@ -14,21 +14,34 @@ orchestration, artifact review, worktree isolation, and cost monitoring.
 
 ## Why Debussy?
 
-The Claude Code ecosystem has 150+ tools, yet a fundamental gap remains: **no
-single tool provides a unified web interface that combines session management,
-workflow orchestration, artifact review, and cost visibility.**
+Three concrete friction points in daily Claude Code use:
 
-The current landscape is fragmented:
+**1. Review UX is broken.** When a workflow produces a 20-item checklist or
+validation report, you have to read through the entire list while simultaneously
+typing your response in a terminal. There's no UI to go item by item, no way to
+approve, flag, or skip with a click. Every review session is a context-switching
+nightmare.
+
+**2. Long workflows need unattended running + visibility.** A full IIKit cycle
+can take 30–60 minutes. You shouldn't have to babysit it — but you also can't
+leave it blind. You need to start a workflow, walk away, and come back to a clear
+picture of where it is, what it produced, and whether it's waiting on you.
+
+**3. Parallel work creates chaos.** Running two features simultaneously means
+either sequential serialization (slow) or branch conflicts and filesystem
+collisions (painful). There's no built-in concept of isolated lanes that let you
+context-switch cleanly between concurrent workstreams.
+
+---
+
+The Claude Code ecosystem has 150+ tools, yet none address these three problems
+together. The current landscape is fragmented:
 
 - **Session management** (recall, claude-history) is TUI/CLI-only — no web UI, no filtering, no tagging
 - **Workflow orchestration** (IIKit, Ralph, GSD) requires manual phase switching via the terminal
 - **Artifact review** (claude-code-viewer) is read-only — you can browse but not approve, edit, or validate
 - **Multi-session monitoring** (claude-squad) depends on tmux — powerful but not visual
 - **Cost tracking** (ccusage) is a separate CLI tool with no integration into the session workflow
-
-Existing web UIs (claudecodeui, claude-code-webui) solve session management
-well but none are workflow-aware. None understand IIKit phases, artifact
-validation, or structured development workflows.
 
 Debussy bridges this gap by combining session management with a workflow
 intelligence layer.
@@ -159,6 +172,7 @@ browser to `http://localhost:3333`.
 
 1. **Workflow definition format** — YAML? JSON? Markdown with frontmatter? Should be human-readable and version-controllable.
 2. **Permission model** — How to surface Claude Code's tool permission prompts in the browser UI.
+3. **Plugin vs. web app** — Debussy may need to become a Claude Code **plugin** (not just a standalone npm package). A plugin can bundle multiple skills (`/debussy:review`, `/debussy:run`, etc.), agents, hooks, and MCP servers under a single namespaced, versioned, distributable unit. The web UI would be a component launched by a skill or hook. This allows skills like `workflow-run` to be first-class Claude Code commands while the server component handles the review UX. See [Claude Code plugin docs](https://code.claude.com/docs/en/plugins.md) for the manifest format.
 
 ## Project Status
 

--- a/PREMISE.md
+++ b/PREMISE.md
@@ -21,13 +21,22 @@ monitoring.
 
 ## Why
 
-The Claude Code ecosystem lacks a unified web interface that combines
-session management, workflow orchestration, artifact review, and cost
-visibility. Session management tools are CLI/TUI-only. Workflow tools
-require manual terminal phase-switching. Artifact viewers are read-only.
-Cost tracking is a separate CLI tool with no integration. Debussy bridges
-this gap by layering workflow intelligence on top of a proven session
-management foundation.
+Three friction points in daily Claude Code use:
+
+1. **Review UX** — reading a 20-item checklist in a terminal while typing
+   responses is high friction. No way to review item-by-item, approve,
+   or flag with a click.
+2. **Workflow visibility** — long workflows (30–60 min) need unattended
+   running with a clear progress view when you return, not constant
+   babysitting.
+3. **Parallel lanes** — running multiple concurrent workstreams causes
+   filesystem conflicts and context-switching chaos without isolated lanes.
+
+The broader ecosystem is also fragmented: session tools are CLI/TUI-only,
+workflow tools require manual terminal phase-switching, artifact viewers
+are read-only, and cost tracking has no integration. Debussy bridges this
+gap by layering workflow intelligence and a review-first UI on top of a
+local web server.
 
 ## Domain
 

--- a/specs/intents.md
+++ b/specs/intents.md
@@ -1,3 +1,100 @@
 # Debussy — Feature Intents
 
-(Intents to be defined)
+Intents are ordered implementation milestones. Each builds on the previous.
+Work in dedicated git worktrees (`feat/<NNN>-<short-name>`).
+
+---
+
+## 000 — Project Bootstrap
+
+Scaffold the Nuxt 4 application, configure Nuxt UI 3, set up Vitest, and verify
+the foundation runs with `npx debussy`. No features — just a working skeleton
+with routing, layout, and a health-check API route.
+
+**Done when:** `npx debussy` starts a server on port 3333, opens the browser to
+a blank dashboard page, and `vitest run` passes.
+
+---
+
+## 001 — IIKit Phase Model
+
+Define the workflow data model: phases, transitions, entry/exit criteria. Build
+the phase-aware UI components (phase stepper, phase card, phase status badges).
+No execution yet — UI + data model only.
+
+**Addresses:** workflow visibility (pain point 2)
+**Done when:** a workflow with 7 IIKit phases renders in the UI with correct
+status display and phase navigation.
+
+---
+
+## 002 — Workflow Runner
+
+Execute IIKit phases via Claude Code subprocess. SSE streaming of output to the
+browser. Auto-advance to the next phase when exit criteria are met. Manual
+override to advance or repeat a phase.
+
+**Addresses:** workflow visibility (pain point 2) — unattended execution
+**Done when:** a full IIKit workflow runs from Specify → Implement via the UI
+with real-time streaming output and phase auto-advance.
+
+---
+
+## 003 — Review UI
+
+Replace the terminal-based review flow with an interactive browser UI. Display
+review items one at a time. Support approve / flag / skip actions per item.
+Produce a structured response that feeds back into the workflow.
+
+**Addresses:** review friction (pain point 1) — the core Debussy differentiator
+**Done when:** a 20-item checklist from an IIKit phase can be reviewed entirely
+in the browser, item by item, producing a structured decision record without
+typing in the terminal.
+
+---
+
+## 004 — Artifact Viewer
+
+Browse, view, and edit the files produced by workflow phases: spec.md, plan.md,
+tasks.md, .feature files, generated code. Validate assertion integrity hashes.
+Diff view for code artifacts.
+
+**Addresses:** review friction (pain point 1) — artifact inspection side
+**Done when:** all IIKit artifact types render correctly with syntax highlighting,
+and assertion hash validation runs on .feature files.
+
+---
+
+## 005 — Worktree Isolation
+
+Create and manage git worktrees for concurrent workflows. Each workflow lane gets
+its own worktree. UI shows active lanes, their branches, and conflict status.
+Switch between lanes without context loss.
+
+**Addresses:** parallel lanes (pain point 3)
+**Done when:** two concurrent IIKit workflows run in separate worktrees without
+filesystem conflicts, with per-lane status visible in the dashboard.
+
+---
+
+## 006 — Cost & Monitoring Panel
+
+Track token consumption, burn rate, and cost per session and workflow. Surface
+context window usage in real-time. Alert when sessions are approaching limits.
+Read from `~/.claude/projects/` JSONL files.
+
+**Addresses:** workflow visibility (pain point 2) — cost side
+**Done when:** token usage and estimated cost display per session, updating in
+real-time during an active workflow.
+
+---
+
+## Future — Plugin Architecture
+
+Explore packaging Debussy as a Claude Code **plugin** (`.claude-plugin/`) that
+bundles multiple skills (`/debussy:review`, `/debussy:run`, `/debussy:status`)
+under a single namespaced, versioned distribution unit. The web server becomes
+a component started by a hook or skill rather than a standalone npm binary.
+
+This is not a current implementation intent — it's a direction to keep in mind
+when making distribution decisions.


### PR DESCRIPTION
## Summary

- **Fix `extraKnownMarketplaces` schema**: converted from array to a typed record (`source.source: "github"`, `source.repo`) to match the Claude Code settings validator
- **Update project docs**: rewrote `INTENT.md` and `PREMISE.md` Why sections with three concrete pain points (review UX, workflow visibility, parallel lanes); expanded `specs/intents.md` with full intent descriptions for 000–006 + future plugin architecture section; updated `CLAUDE.md` intent sequencing to include the Review UI (003) and shift subsequent intents accordingly

## Test plan

- [ ] Run `/doctor` in the debussy project — no settings validation errors
- [ ] Verify marketplace entry resolves: `extraKnownMarketplaces.debussy` points to `jcbianic/debussy` on GitHub
- [ ] Review updated intent descriptions in `specs/intents.md` for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)