### PR TITLE
fix: use lanes.value in computed for activeLaneCount

### DIFF
--- a/ui/pages/index.vue
+++ b/ui/pages/index.vue
@@ -306,5 +306,7 @@ const { nextRelease, nextReleaseName, artifacts, claudeStats, claudeItems } =
 const lanesWithPending = computed(() =>
   allLanesWithPending.value.filter((l) => l.pending > 0)
 )
-const activeLaneCount = lanes.filter((l) => l.isActive).length
+const activeLaneCount = computed(
+  () => lanes.value.filter((l) => l.isActive).length
+)
 </script>


### PR DESCRIPTION
## Fix

The dashboard page was throwing 'lanes.filter is not a function' error because `lanes` is a Ref and cannot call .filter() directly. 

## Solution

Wrap `activeLaneCount` in a computed() to properly access `lanes.value`, consistent with the `lanesWithPending` pattern already used in the same file.

## Testing

Dashboard page now loads without 500 errors.

🤖 Generated with [Claude Code](https://claude.ai/code)