### PR TITLE
feat(#68): release management skill — full lifecycle orchestration

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,0 +1,61 @@
+---
+description: "Create a well-structured git commit following conventional commits"
+allowed-tools: "Bash, Read, Grep, Glob"
+delegates-to: " "
+---
+
+# Commit Command
+
+Create a clean, well-structured git commit.
+
+## Commit policy
+
+**Commit early and often.** Every coherent change deserves its own commit —
+don't batch unrelated work, don't wait for "clean" state. Small commits are
+cheap; lost work is not.
+
+**Artifact commits** use the `wip(artifacts)` type for generated or temporary
+files (specs, plans, debug traces, snapshots, generated outputs) that may be
+squashed or dropped before merging the branch. This keeps the history
+navigable without polluting it with noise that outlives the feature.
+
+## 1. Assess the situation
+
+Run these in parallel:
+
+- `git status` to see all changed files
+- `git diff --cached` to see staged changes
+- `git diff` to see unstaged changes
+- `git log --oneline -5` to see recent commit style
+
+## 2. Stage changes
+
+- If nothing is staged, review all changes and suggest what to stage
+- Group related changes into one commit; separate artifact-only changes
+  into a `wip(artifacts)` commit
+- Never stage files that contain secrets
+- Prefer `git add <specific files>` over `git add .`
+
+## 3. Draft the commit message
+
+Follow conventional commits: `type(scope): description`
+
+Types: feat, fix, refactor, chore, docs, test, style, perf, ci, **wip**
+
+- `wip(artifacts): <description>` — for generated/temporary files meant
+  to be cleaned before merge
+- Keep the subject line under 72 characters
+- Focus on **why**, not **what**
+- Use imperative mood ("add" not "added")
+
+If the user provided an intent as argument, use it to guide the message.
+
+## 4. Commit
+
+- Never use `--no-verify` or skip hooks
+- Never amend unless explicitly asked
+- Pass the message via HEREDOC for proper formatting
+
+## 5. Confirm
+
+Show the result with `git log --oneline -1` and `git status`.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -62,10 +62,7 @@ target milestone. Otherwise, list milestones and ask the user.
 Run this sub-step in all modes that reference a milestone:
 
 ```bash
-gh milestone list \
-  --json number,title,dueOn,description \
-  --state open \
-  --limit 50
+bash .claude/skills/release/scripts/list-milestones.sh
 ```
 
 If `[milestone]` argument was provided:
@@ -95,27 +92,15 @@ Assess milestone health and write scope artifact.
 
 See Step 2.
 
-### Fetch all open issues in milestone
+### Fetch all open issues in milestone + assess health
 
 ```bash
-gh issue list \
-  --milestone "{milestone_title}" \
-  --state open \
-  --json number,title,labels,body \
-  --limit 100
+bash .claude/skills/release/scripts/fetch-issues.sh "{milestone_title}"
 ```
 
-### Assess Health
-
-- Count total issues
-- Group by label (count `ready`, `design`, `blocked`, etc.)
-- For each issue, check body for markers:
-  - Acceptance criteria: look for `## Acceptance Criteria` or
-    `- [ ]` checklist
-  - Description clarity: flag if <50 words or missing clear
-    summary
-  - Labels: flag if no priority/status label
-- Compile flags list: vague issues, unlabeled, no criteria
+The script outputs: issues table, health scorecard, and flagged
+issues list. Use this output directly — do not re-fetch or
+re-analyze.
 
 ### Initialize or read artifact
 
@@ -416,37 +401,13 @@ Read `.debussy/releases/{milestone_slug}.md`. Verify `phase` is
 
 ### Fetch lane status
 
-For each lane in artifact:
-
 ```bash
-gh pr view {lane_pr_number} \
-  --json state,reviewDecision,isDraft,commits
+bash .claude/skills/release/scripts/track-lanes.sh "{milestone_slug}"
 ```
 
-Extract: PR state (OPEN, MERGED, CLOSED), review decision
-(APPROVED, CHANGES_REQUESTED, PENDING), draft status, commit count.
-
-Check git log for last commit timestamp:
-
-```bash
-git log -1 --format=%ai lane/{issue_number}-{slug}
-```
-
-Determine if stale (no commit in >48h).
-
-### Build lane status table
-
-```text
-Lane | Issue | Branch | PR | State | Review | Stale? | Merged?
-{N} | #{issue} | lane/{N} | #{pr} | OPEN | pending | - | no
-```
-
-### Identify blockers
-
-- PRs with `CHANGES_REQUESTED` → flag
-- PRs with `isDraft: true` → flag
-- Stale lanes (no commit >48h) → flag
-- Lanes with `state: created` (no work started) → flag
+The script outputs: per-lane status table, summary counts, and
+action-required items. Use this output directly — do not re-fetch
+individual PR states.
 
 ### Update artifact
 
@@ -509,10 +470,13 @@ Read `.debussy/releases/{milestone_slug}.md`. Verify `phase` is
 
 ### Check lane status
 
-Run Track Mode logic (fetch all lane PR statuses).
+```bash
+bash .claude/skills/release/scripts/close-checks.sh "{milestone_slug}"
+```
 
-If any lane PR is not `MERGED`, ask user:
-"Lane {N} PR #{pr} is not merged ({state}). Skip or wait?"
+Exit 0 = all lanes merged (GO). Exit 1 = unmerged lanes remain
+(NO-GO) — the script lists them. If NO-GO, ask user for each
+unmerged lane: "Skip or wait?"
 
 If "wait", exit. If "skip", mark as skipped.
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,679 @@
+---
+description: >-
+  Manage the full lifecycle of a GitHub milestone-based release —
+  from preparation to close. Commands: /release | /release --prepare
+  [milestone] | /release --mature [milestone] | /release --scaffold
+  [milestone] | /release --track [milestone] | /release --close
+  [milestone]
+license: MIT
+metadata:
+  author: jcbianic
+  version: "0.1.0"
+---
+
+# Release Skill
+
+Manage the full lifecycle of a release anchored to a GitHub milestone.
+The skill covers: preparing scope, maturing issues to readiness,
+scaffolding all lanes in one command, tracking progress, and closing
+the release.
+
+**Output is terminal-only.** This skill is a pure orchestrator.
+
+## When to Activate
+
+- User says "manage a release", "prepare a release", "close a release"
+- User invokes `/release`
+- User wants to scaffold lanes for a milestone
+- User wants to track release progress
+
+## Usage
+
+```text
+/release                       # List milestones → prompt → prepare
+/release --prepare [milestone] # Phase 1: assess health, write
+/release --mature [milestone]  # Phase 2: evaluate readiness
+/release --scaffold [milestone]# Phase 3: create release branch +
+/release --track [milestone]   # Phase 4: show lane progress
+/release --close [milestone]   # Phase 5: squash-merge → release
+```
+
+---
+
+## Step 1: Parse Arguments
+
+From `$ARGUMENTS`, determine mode:
+
+- If `--list` → jump to **List Mode**
+- If `--prepare` → jump to **Prepare Mode**
+- If `--mature` → jump to **Mature Mode**
+- If `--scaffold` → jump to **Scaffold Mode**
+- If `--track` → jump to **Track Mode**
+- If `--close` → jump to **Close Mode**
+- Otherwise → jump to **Default Mode** (list milestones, prompt)
+
+Extract optional `[milestone]` argument. If present, use it as the
+target milestone. Otherwise, list milestones and ask the user.
+
+---
+
+## Step 2: Resolve Milestone
+
+Run this sub-step in all modes that reference a milestone:
+
+```bash
+gh milestone list \
+  --json number,title,dueOn,description \
+  --state open \
+  --limit 50
+```
+
+If `[milestone]` argument was provided:
+
+- Try exact match on title (case-insensitive)
+- If not found, try slug match (derive slug from title: lowercase,
+  spaces/dots → `-`, strip non-alphanumeric)
+- If still not found, ask user via AskUserQuestion with the list
+
+Extract: `milestone_number`, `milestone_title`, `milestone_slug`,
+`due_on`, `description`.
+
+---
+
+## Default Mode
+
+Resolve the milestone and jump to **Prepare Mode** with the selected
+milestone.
+
+---
+
+## Prepare Mode
+
+Assess milestone health and write scope artifact.
+
+### Resolve Milestone (Prepare)
+
+See Step 2.
+
+### Fetch all open issues in milestone
+
+```bash
+gh issue list \
+  --milestone "{milestone_title}" \
+  --state open \
+  --json number,title,labels,body \
+  --limit 100
+```
+
+### Assess Health
+
+- Count total issues
+- Group by label (count `ready`, `design`, `blocked`, etc.)
+- For each issue, check body for markers:
+  - Acceptance criteria: look for `## Acceptance Criteria` or
+    `- [ ]` checklist
+  - Description clarity: flag if <50 words or missing clear
+    summary
+  - Labels: flag if no priority/status label
+- Compile flags list: vague issues, unlabeled, no criteria
+
+### Initialize or read artifact
+
+Check if `.debussy/releases/{milestone_slug}.md` exists.
+
+- If yes, preserve non-empty sections (scope, phase history)
+- If no, create new
+
+### Write artifact with sections
+
+```markdown
+---
+milestone: {milestone_title}
+milestone_number: {number}
+release_branch: release/v{version}
+pr_number: null
+phase: prepared
+created_at: {ISO-8601}
+updated_at: {ISO-8601}
+---
+
+# Release: {milestone_title}
+
+## Overview
+
+{milestone_description}
+
+**Due:** {due_on or "unset"}
+
+## Issues ({count} open)
+
+| # | Title | Labels | Ready? |
+| --- | --- | --- | --- |
+| {N} | {title} | {labels} | {flag or ✓} |
+
+## Health Scorecard
+
+- **Size:** {count} issues
+- **Labeled:** {count_labeled}/{count}
+- **Ready:** {count_ready}/{count}
+- **Critical Blocks:** {count_blocked}
+
+## Flagged Issues
+
+{for each flagged issue:}
+- Issue #{N} ({title}): {flag reason}
+```
+
+### Print Prepare Summary
+
+```text
+RELEASE PREPARED: {milestone_title}
+
+Issues: {count} open
+Health: {scorecard summary}
+Flagged: {count_flagged}
+
+Flagged issues:
+{list}
+
+Next: /release --mature {milestone_slug}
+```
+
+---
+
+## Mature Mode
+
+Evaluate issue readiness and suggest improvements.
+
+### Resolve Milestone (Mature)
+
+See Step 2.
+
+### Read Release Artifact (Mature)
+
+Read `.debussy/releases/{milestone_slug}.md`. If missing, error:
+"Release not prepared. Run `/release --prepare {milestone}` first."
+Exit.
+
+### For each flagged issue
+
+- Fetch full issue body: `gh issue view {N} --json body,labels`
+- Evaluate:
+  - Missing acceptance criteria → suggest label addition
+  - Vague description → ask for clarification
+  - Missing labels → suggest label additions
+  - Suggest: run `gh issue edit {N} --add-label "ready"` (if fixed)
+
+### Prompt user
+
+```text
+Found {count_flagged} issues needing maturity:
+
+{for each flagged issue:}
+- Issue #{N}: {current issue}
+  Suggestion: {gh issue edit command or clarification}
+
+Apply suggestions? (yes/no/skip-{N}/edit-body-{N})
+```
+
+AskUserQuestion with these options.
+
+### Apply decisions
+
+- If user provides `yes`, run all suggested `gh issue edit`
+  commands
+- If `skip-{N}`, remove that issue from flags
+- If `edit-body-{N}`, print the issue body and ask user for edits
+
+### Update Release Artifact (Mature)
+
+```markdown
+phase: matured
+updated_at: {ISO-8601}
+```
+
+### Print Mature Summary
+
+```text
+RELEASE MATURED: {milestone_title}
+
+Issues evaluated: {count_flagged}
+Applied edits: {count_applied}
+
+Next: /release --scaffold {milestone_slug}
+```
+
+---
+
+## Scaffold Mode
+
+Create release branch and lanes for all issues.
+
+### Resolve Milestone (Scaffold)
+
+See Step 2.
+
+### Read Release Artifact (Scaffold)
+
+Read `.debussy/releases/{milestone_slug}.md`. Verify `phase` is
+`prepared` or `matured`. If not, error and exit.
+
+### Derive release version
+
+From milestone_title, extract version. E.g., "v0.2.0" → "0.2.0".
+If not in vX.Y.Z format, ask user:
+"What version number for this release? (e.g., 0.2.0)"
+
+### Create release branch
+
+```bash
+git checkout -b release/v{version} main
+git push -u origin release/v{version}
+```
+
+### Create draft PR (release → main)
+
+```bash
+gh pr create \
+  --title "Release v{version}" \
+  --body "Merge when all lanes approved." \
+  --draft \
+  --base main \
+  --head release/v{version}
+```
+
+Extract `pr_number` from output.
+
+### For each issue in milestone
+
+Fetch issue details:
+
+```bash
+gh issue view {issue_number} \
+  --json number,title,body,labels
+```
+
+Derive slug: lowercase title, spaces/dots → `-`,
+strip non-alphanumeric.
+
+Create lane branch (from `release/v{version}`):
+
+```bash
+git checkout release/v{version}
+git checkout -b lane/{issue_number}-{slug}
+git push -u origin lane/{issue_number}-{slug}
+```
+
+Create worktree:
+
+```bash
+git worktree add \
+  .worktrees/{issue_number} \
+  lane/{issue_number}-{slug}
+```
+
+Create draft PR (lane → release branch):
+
+```bash
+gh pr create \
+  --title "Lane {issue_number}: {title}" \
+  --body "{issue_body}" \
+  --draft \
+  --base release/v{version} \
+  --head lane/{issue_number}-{slug}
+```
+
+Extract `lane_pr_number`.
+
+Write `.debussy/lanes/{issue_number}/lane.json`:
+
+```json
+{
+  "id": "{issue_number}",
+  "issueNumber": {issue_number},
+  "issueTitle": "{title}",
+  "branch": "lane/{issue_number}-{slug}",
+  "worktreePath": ".worktrees/{issue_number}",
+  "baseBranch": "release/v{version}",
+  "prNumber": {lane_pr_number},
+  "state": "created",
+  "releaseSlug": "{milestone_slug}",
+  "createdAt": "{ISO-8601}",
+  "updatedAt": "{ISO-8601}"
+}
+```
+
+Write `.debussy/lanes/{issue_number}/scope.md`:
+
+```markdown
+# Lane {issue_number}: {title}
+
+## Release
+
+{milestone_title} (`release/v{version}`)
+
+## Summary
+
+{issue_body, first 500 chars}
+
+## Acceptance Criteria
+
+{if present in issue body, extracted section}
+{else: "(not yet specified)"}
+```
+
+Create empty `.debussy/lanes/{issue_number}/sessions/` directory.
+
+### Update Release Artifact (Scaffold)
+
+Add lane table to artifact:
+
+```markdown
+## Lanes ({count} created)
+
+| Lane | Issue | Branch | PR | Status |
+| --- | --- | --- | --- | --- |
+| {N} | #{issue} {title} | lane/{N}-{slug} | #{pr} | created |
+```
+
+Update frontmatter:
+
+```yaml
+release_branch: release/v{version}
+pr_number: {pr_number}
+phase: scaffolded
+updated_at: {ISO-8601}
+```
+
+### Print
+
+```text
+RELEASE SCAFFOLDED: {milestone_title} (v{version})
+
+Release branch: release/v{version}
+Release PR: #{pr_number}
+
+Lanes created: {count}
+Worktrees created: {count}
+
+Next: /release --track {milestone_slug}
+```
+
+---
+
+## Track Mode
+
+Show lane progress and identify blockers.
+
+### Resolve Milestone
+
+See Step 2.
+
+### Read artifact
+
+Read `.debussy/releases/{milestone_slug}.md`. Verify `phase` is
+`scaffolded` or `tracking`. If not, error and exit.
+
+### Fetch lane status
+
+For each lane in artifact:
+
+```bash
+gh pr view {lane_pr_number} \
+  --json state,reviewDecision,isDraft,commits
+```
+
+Extract: PR state (OPEN, MERGED, CLOSED), review decision
+(APPROVED, CHANGES_REQUESTED, PENDING), draft status, commit count.
+
+Check git log for last commit timestamp:
+
+```bash
+git log -1 --format=%ai lane/{issue_number}-{slug}
+```
+
+Determine if stale (no commit in >48h).
+
+### Build lane status table
+
+```text
+Lane | Issue | Branch | PR | State | Review | Stale? | Merged?
+{N} | #{issue} | lane/{N} | #{pr} | OPEN | pending | - | no
+```
+
+### Identify blockers
+
+- PRs with `CHANGES_REQUESTED` → flag
+- PRs with `isDraft: true` → flag
+- Stale lanes (no commit >48h) → flag
+- Lanes with `state: created` (no work started) → flag
+
+### Update artifact
+
+Add or replace "Track" section:
+
+```markdown
+## Lane Status
+
+| Lane | Issue | PR | State | Review | Blocked? |
+| --- | --- | --- | --- | --- | --- |
+{table rows}
+
+### Blockers
+
+{for each blocked lane:}
+- Lane {N} ({title}): {blocker type}
+```
+
+Update:
+
+```yaml
+phase: tracking
+updated_at: {ISO-8601}
+```
+
+### Print Track Summary
+
+```text
+RELEASE TRACK: {milestone_title}
+
+Lanes: {count} total
+  Created: {count}
+  In Progress: {count}
+  Ready for Review: {count}
+  Merged: {count}
+
+Blockers: {count}
+{list}
+
+Stale Lanes (no commit >48h): {count}
+{list}
+
+Next: /release --close {milestone_slug} (when all PRs merged)
+```
+
+---
+
+## Close Mode
+
+Show lane progress and identify blockers.
+
+### Resolve Milestone (Track)
+
+See Step 2.
+
+### Read Release Artifact (Track)
+
+Read `.debussy/releases/{milestone_slug}.md`. Verify `phase` is
+`tracking` or `scaffolded`. If not, error and exit.
+
+### Check lane status
+
+Run Track Mode logic (fetch all lane PR statuses).
+
+If any lane PR is not `MERGED`, ask user:
+"Lane {N} PR #{pr} is not merged ({state}). Skip or wait?"
+
+If "wait", exit. If "skip", mark as skipped.
+
+### Merge release PR
+
+```bash
+gh pr merge {release_pr_number} \
+  --squash \
+  --auto
+```
+
+Wait for merge (poll `gh pr view {release_pr_number} --json state`
+until `MERGED`).
+
+### Create GitHub release
+
+Derive release notes from milestone description + issue titles:
+
+```bash
+gh release create v{version} \
+  --title "v{version}" \
+  --notes "{release_notes}" \
+  --target main
+```
+
+### Close milestone
+
+```bash
+gh api repos/{owner}/{repo}/milestones/{milestone_number} \
+  -X PATCH \
+  -F state=closed
+```
+
+### Append retrospective to artifact
+
+```markdown
+## Retrospective
+
+**Closed at:** {ISO-8601}
+**Duration:** {created_at to now}
+**Issues delivered:** {count_merged}
+**Lanes completed:** {count_merged}
+**Blockers resolved:** {count_blockers}
+
+### Summary
+
+{user input via prompt:}
+"Retrospective notes for this release? (freeform)"
+
+[include user input]
+```
+
+Update frontmatter:
+
+```yaml
+phase: closed
+updated_at: {ISO-8601}
+```
+
+### Print Close Summary
+
+```text
+RELEASE CLOSED: {milestone_title} (v{version})
+
+Release PR: #{release_pr_number} merged
+GitHub Release: v{version} created
+Milestone: closed
+
+Issues delivered: {count}
+Lanes merged: {count}
+
+Release artifact: .debussy/releases/{milestone_slug}.md
+```
+
+---
+
+## Artifact Format Rules
+
+### Release Artifact Path
+
+`.debussy/releases/{milestone_slug}.md` where slug is derived from
+milestone title: lowercase, spaces/dots → `-`, remove
+non-alphanumeric, collapse dashes.
+
+Example: "Release v0.2.0 — Milestone" →
+`release-v0-2-0-milestone`
+
+### Frontmatter
+
+```yaml
+milestone: {milestone_title}
+milestone_number: {gh milestone number}
+release_branch: release/v{version}
+pr_number: {gh pr number or null}
+phase: prepared | matured | scaffolded | tracking | closed
+created_at: {ISO-8601}
+updated_at: {ISO-8601}
+```
+
+### Sections
+
+- **Overview:** milestone description + due date
+- **Issues:** table of all issues with flags
+- **Health Scorecard:** size, labeled %, ready %, blocked count
+- **Flagged Issues:** per-issue suggestions
+- **Lanes:** (after scaffold) table of branch → PR mappings
+- **Lane Status:** (after track) table of PR states + blockers
+- **Retrospective:** (after close) summary + user notes
+
+### Lane Record (`.debussy/lanes/{N}/lane.json`)
+
+New field `baseBranch` points to the release branch (not main).
+New field `releaseSlug` for tracking which release owns the lane.
+
+```json
+{
+  "id": "{issueNumber}",
+  "issueNumber": {N},
+  "issueTitle": "{title}",
+  "branch": "lane/{N}-{slug}",
+  "worktreePath": ".worktrees/{N}",
+  "baseBranch": "release/v{version}",
+  "prNumber": {lane_pr_number},
+  "state": "created",
+  "releaseSlug": "{milestone_slug}",
+  "createdAt": "{ISO-8601}",
+  "updatedAt": "{ISO-8601}"
+}
+```
+
+### Scope Template (`.debussy/lanes/{N}/scope.md`)
+
+```markdown
+# Lane {N}: {issueTitle}
+
+## Release
+
+{milestone_title} (`release/v{version}`)
+
+## Summary
+
+{issue body excerpt, first 500 chars}
+
+## Acceptance Criteria
+
+{extracted from issue body if marked}
+{else: "(not yet specified)"}
+```
+
+---
+
+## Error Handling
+
+| Situation | Action |
+| --- | --- |
+| Milestone not found | List milestones, ask user to pick |
+| Release artifact missing | Print error, suggest `--prepare` |
+| Phase mismatch | Print warning, ask to proceed |
+| `gh` command fails | Print error, suggest `gh auth login` |
+| Git worktree exists | Warn, ask skip or remove-recreate |
+| Lane branch exists | Warn, ask skip or force |
+| PR merge fails | Print error, ask user resolve |
+| Release version not detected | Prompt user for version |
+| Not all lanes merged | Print warning, ask confirmation |

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -390,7 +390,7 @@ Next: /release --track {milestone_slug}
 
 Show lane progress and identify blockers.
 
-### Resolve Milestone
+### Resolve Milestone (Track)
 
 See Step 2.
 
@@ -459,11 +459,11 @@ Next: /release --close {milestone_slug} (when all PRs merged)
 
 Show lane progress and identify blockers.
 
-### Resolve Milestone (Track)
+### Resolve Milestone (Close)
 
 See Step 2.
 
-### Read Release Artifact (Track)
+### Read Release Artifact (Close)
 
 Read `.debussy/releases/{milestone_slug}.md`. Verify `phase` is
 `tracking` or `scaffolded`. If not, error and exit.
@@ -496,10 +496,13 @@ until `MERGED`).
 Derive release notes from milestone description + issue titles:
 
 ```bash
+NOTES_FILE=$(mktemp /tmp/release-notes-XXXXXX.md)
+printf '%s' "{release_notes}" > "$NOTES_FILE"
 gh release create v{version} \
   --title "v{version}" \
-  --notes "{release_notes}" \
+  --notes-file "$NOTES_FILE" \
   --target main
+rm -f "$NOTES_FILE"
 ```
 
 ### Close milestone

--- a/.claude/skills/release/scripts/close-checks.sh
+++ b/.claude/skills/release/scripts/close-checks.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Pre-close validation: check all lanes are merged
+# Usage: close-checks.sh <milestone_slug>
+# Exit 0 = GO, Exit 1 = NO-GO (unmerged lanes remain)
+
+set -euo pipefail
+
+MILESTONE_SLUG="${1:?Usage: close-checks.sh <milestone_slug>}"
+LANES_DIR=".debussy/lanes"
+RELEASE_FILE=".debussy/releases/${MILESTONE_SLUG}.md"
+
+echo "=== CLOSE CHECKS: $MILESTONE_SLUG ==="
+echo ""
+
+if [ ! -f "$RELEASE_FILE" ]; then
+  echo "ERROR: Release artifact not found: $RELEASE_FILE"
+  echo "Run: /release --prepare $MILESTONE_SLUG"
+  exit 1
+fi
+
+if [ ! -d "$LANES_DIR" ]; then
+  echo "ERROR: No lanes directory at $LANES_DIR"
+  exit 1
+fi
+
+TOTAL=0
+MERGED_COUNT=0
+UNMERGED_COUNT=0
+
+for lane_file in "$LANES_DIR"/*/lane.json; do
+  [ -f "$lane_file" ] || continue
+
+  RELEASE_SLUG=$(jq -r '.releaseSlug // ""' "$lane_file")
+  [ "$RELEASE_SLUG" = "$MILESTONE_SLUG" ] || continue
+
+  ISSUE_NUM=$(jq -r '.issueNumber' "$lane_file")
+  TITLE=$(jq -r '.issueTitle' "$lane_file")
+  PR_NUM=$(jq -r '.prNumber' "$lane_file")
+
+  TOTAL=$((TOTAL + 1))
+
+  STATE=$(gh pr view "$PR_NUM" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
+
+  if [ "$STATE" = "MERGED" ]; then
+    MERGED_COUNT=$((MERGED_COUNT + 1))
+    echo "  ok   #$ISSUE_NUM  PR#$PR_NUM  $TITLE"
+  else
+    UNMERGED_COUNT=$((UNMERGED_COUNT + 1))
+    echo "  WAIT #$ISSUE_NUM  PR#$PR_NUM  $TITLE  ($STATE)"
+  fi
+done
+
+echo ""
+echo "--- Verdict ---"
+echo "  Lanes: $MERGED_COUNT/$TOTAL merged"
+
+if [ "$UNMERGED_COUNT" -eq 0 ]; then
+  echo "  STATUS: GO — all lanes merged, safe to close release"
+  exit 0
+else
+  echo "  STATUS: NO-GO — $UNMERGED_COUNT lane(s) not yet merged"
+  echo "  Resolve before closing or confirm skip with user"
+  exit 1
+fi

--- a/.claude/skills/release/scripts/close-checks.sh
+++ b/.claude/skills/release/scripts/close-checks.sh
@@ -54,6 +54,12 @@ echo ""
 echo "--- Verdict ---"
 echo "  Lanes: $MERGED_COUNT/$TOTAL merged"
 
+if [ "$TOTAL" -eq 0 ]; then
+  echo "  STATUS: NO-GO — no lanes found for milestone '$MILESTONE_SLUG'"
+  echo "  Check that lanes were scaffolded and releaseSlug matches"
+  exit 1
+fi
+
 if [ "$UNMERGED_COUNT" -eq 0 ]; then
   echo "  STATUS: GO — all lanes merged, safe to close release"
   exit 0

--- a/.claude/skills/release/scripts/fetch-issues.sh
+++ b/.claude/skills/release/scripts/fetch-issues.sh
@@ -32,7 +32,7 @@ echo "$ISSUES" | jq -r '.[] | [
   (
     [
       if (.body | length) < 50 then "SHORT_BODY" else empty end,
-      if (.body | test("(?i)## Acceptance Criteria|\\- \\[ \\]") | not) then "NO_CRITERIA" else empty end,
+      if ((.body // "") | test("(?i)## Acceptance Criteria|\\- \\[ \\]") | not) then "NO_CRITERIA" else empty end,
       if (.labels | length) == 0 then "NO_LABELS" else empty end
     ] | if length > 0 then join(", ") else "ok" end
   )
@@ -52,7 +52,7 @@ echo "$ISSUES" | jq -r --argjson total "$TOTAL" '
     flagged: ([
       .[] | select(
         (.body | length) < 50 or
-        (.body | test("(?i)## Acceptance Criteria|\\- \\[ \\]") | not) or
+        ((.body // "") | test("(?i)## Acceptance Criteria|\\- \\[ \\]") | not) or
         (.labels | length) == 0
       )
     ] | length)
@@ -72,7 +72,7 @@ FLAGGED=$(echo "$ISSUES" | jq -r '.[] |
   . as $i |
   [
     if (.body | length) < 50 then "SHORT_BODY" else empty end,
-    if (.body | test("(?i)## Acceptance Criteria|\\- \\[ \\]") | not) then "NO_CRITERIA" else empty end,
+    if ((.body // "") | test("(?i)## Acceptance Criteria|\\- \\[ \\]") | not) then "NO_CRITERIA" else empty end,
     if (.labels | length) == 0 then "NO_LABELS" else empty end
   ] as $flags |
   if ($flags | length) > 0 then

--- a/.claude/skills/release/scripts/fetch-issues.sh
+++ b/.claude/skills/release/scripts/fetch-issues.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Fetch issues for a milestone + health analysis
+# Usage: fetch-issues.sh <milestone_title>
+# Output: issues table, health scorecard, flagged issues
+
+set -euo pipefail
+
+MILESTONE="${1:?Usage: fetch-issues.sh <milestone_title>}"
+
+echo "=== ISSUES: $MILESTONE ==="
+echo ""
+
+ISSUES=$(gh issue list \
+  --milestone "$MILESTONE" \
+  --state open \
+  --json number,title,labels,body \
+  --limit 100)
+
+TOTAL=$(echo "$ISSUES" | jq 'length')
+
+if [ "$TOTAL" -eq 0 ]; then
+  echo "No open issues found for milestone: $MILESTONE"
+  exit 0
+fi
+
+# --- Issues table ---
+echo "--- Issues ---"
+echo "$ISSUES" | jq -r '.[] | [
+  "#\(.number)",
+  .title,
+  ([ .labels[].name ] | if length > 0 then join(", ") else "(none)" end),
+  (
+    [
+      if (.body | length) < 50 then "SHORT_BODY" else empty end,
+      if (.body | test("(?i)## Acceptance Criteria|\\- \\[ \\]") | not) then "NO_CRITERIA" else empty end,
+      if (.labels | length) == 0 then "NO_LABELS" else empty end
+    ] | if length > 0 then join(", ") else "ok" end
+  )
+] | "\(.[0])  \(.[1])  [\(.[2])]  flags:\(.[3])"'
+
+echo ""
+
+# --- Health scorecard ---
+echo "--- Health Scorecard ---"
+echo "$ISSUES" | jq -r --argjson total "$TOTAL" '
+  ($total) as $n |
+  {
+    size: $n,
+    labeled: ([ .[] | select(.labels | length > 0) ] | length),
+    ready: ([ .[] | select(any(.labels[]; .name == "ready")) ] | length),
+    blocked: ([ .[] | select(any(.labels[]; .name == "blocked")) ] | length),
+    flagged: ([
+      .[] | select(
+        (.body | length) < 50 or
+        (.body | test("(?i)## Acceptance Criteria|\\- \\[ \\]") | not) or
+        (.labels | length) == 0
+      )
+    ] | length)
+  } |
+  "  Size:    \(.size) issues",
+  "  Labeled: \(.labeled)/\(.size)",
+  "  Ready:   \(.ready)/\(.size)",
+  "  Blocked: \(.blocked)",
+  "  Flagged: \(.flagged)"
+'
+
+echo ""
+
+# --- Flagged issues ---
+echo "--- Flagged Issues ---"
+FLAGGED=$(echo "$ISSUES" | jq -r '.[] |
+  . as $i |
+  [
+    if (.body | length) < 50 then "SHORT_BODY" else empty end,
+    if (.body | test("(?i)## Acceptance Criteria|\\- \\[ \\]") | not) then "NO_CRITERIA" else empty end,
+    if (.labels | length) == 0 then "NO_LABELS" else empty end
+  ] as $flags |
+  if ($flags | length) > 0 then
+    "  #\(.number) (\(.title)): \($flags | join(", "))"
+  else empty end
+')
+
+if [ -z "$FLAGGED" ]; then
+  echo "  None — all issues look healthy"
+else
+  echo "$FLAGGED"
+fi

--- a/.claude/skills/release/scripts/list-milestones.sh
+++ b/.claude/skills/release/scripts/list-milestones.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# List open GitHub milestones — formatted for release skill
+# Usage: list-milestones.sh
+# Output: numbered list with number, title, due date, description excerpt
+
+set -euo pipefail
+
+echo "=== OPEN MILESTONES ==="
+echo ""
+
+MILESTONES=$(gh milestone list \
+  --json number,title,dueOn,description \
+  --state open \
+  --limit 50)
+
+COUNT=$(echo "$MILESTONES" | jq 'length')
+
+if [ "$COUNT" -eq 0 ]; then
+  echo "No open milestones found."
+  exit 0
+fi
+
+echo "$MILESTONES" | jq -r '.[] |
+  "#\(.number)  \(.title)  due:\(.dueOn // "unset")  \((.description // "") | if length > 60 then .[:60] + "..." else . end)"
+'
+
+echo ""
+echo "Total: $COUNT milestone(s)"

--- a/.claude/skills/release/scripts/track-lanes.sh
+++ b/.claude/skills/release/scripts/track-lanes.sh
@@ -37,7 +37,7 @@ for lane_file in "$LANES_DIR"/*/lane.json; do
   [ "$RELEASE_SLUG" = "$MILESTONE_SLUG" ] || continue
 
   ISSUE_NUM=$(jq -r '.issueNumber' "$lane_file")
-  TITLE=$(jq -r '.issueTitle' "$lane_file")
+  TITLE=$(jq -r '.issueTitle // ""' "$lane_file")
   BRANCH=$(jq -r '.branch' "$lane_file")
   PR_NUM=$(jq -r '.prNumber' "$lane_file")
 

--- a/.claude/skills/release/scripts/track-lanes.sh
+++ b/.claude/skills/release/scripts/track-lanes.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Track lane PR status for a release milestone
+# Usage: track-lanes.sh <milestone_slug>
+# Output: status table, summary counts, blockers list
+
+set -euo pipefail
+
+MILESTONE_SLUG="${1:?Usage: track-lanes.sh <milestone_slug>}"
+LANES_DIR=".debussy/lanes"
+
+echo "=== LANE TRACK: $MILESTONE_SLUG ==="
+echo ""
+
+if [ ! -d "$LANES_DIR" ]; then
+  echo "ERROR: No lanes directory at $LANES_DIR"
+  echo "Run: /release --scaffold $MILESTONE_SLUG"
+  exit 1
+fi
+
+NOW=$(date +%s)
+STALE_THRESHOLD=$((48 * 3600))
+
+TOTAL=0
+CREATED=0
+IN_PROGRESS=0
+READY=0
+MERGED_COUNT=0
+BLOCKED=0
+STALE_COUNT=0
+
+echo "--- Lane Status ---"
+
+for lane_file in "$LANES_DIR"/*/lane.json; do
+  [ -f "$lane_file" ] || continue
+
+  RELEASE_SLUG=$(jq -r '.releaseSlug // ""' "$lane_file")
+  [ "$RELEASE_SLUG" = "$MILESTONE_SLUG" ] || continue
+
+  ISSUE_NUM=$(jq -r '.issueNumber' "$lane_file")
+  TITLE=$(jq -r '.issueTitle' "$lane_file")
+  BRANCH=$(jq -r '.branch' "$lane_file")
+  PR_NUM=$(jq -r '.prNumber' "$lane_file")
+
+  TOTAL=$((TOTAL + 1))
+
+  # Fetch PR status
+  if ! PR_DATA=$(gh pr view "$PR_NUM" --json state,reviewDecision,isDraft,commits 2>/dev/null); then
+    echo "  #$ISSUE_NUM  PR#$PR_NUM  ERROR fetching PR"
+    continue
+  fi
+
+  STATE=$(echo "$PR_DATA" | jq -r '.state')
+  REVIEW=$(echo "$PR_DATA" | jq -r '.reviewDecision // "PENDING"')
+  IS_DRAFT=$(echo "$PR_DATA" | jq -r '.isDraft')
+
+  # Stale check via git log on remote branch
+  STALE_FLAG="-"
+  if LAST_COMMIT_AT=$(git log -1 --format=%at "origin/$BRANCH" 2>/dev/null); then
+    AGE=$((NOW - LAST_COMMIT_AT))
+    if [ "$AGE" -gt "$STALE_THRESHOLD" ] && [ "$STATE" = "OPEN" ]; then
+      STALE_FLAG="STALE"
+      STALE_COUNT=$((STALE_COUNT + 1))
+    fi
+  fi
+
+  # Classify
+  if [ "$STATE" = "MERGED" ]; then
+    MERGED_COUNT=$((MERGED_COUNT + 1))
+    STATUS_LABEL="MERGED"
+  elif [ "$REVIEW" = "CHANGES_REQUESTED" ]; then
+    BLOCKED=$((BLOCKED + 1))
+    STATUS_LABEL="BLOCKED(changes)"
+  elif [ "$IS_DRAFT" = "true" ]; then
+    IN_PROGRESS=$((IN_PROGRESS + 1))
+    STATUS_LABEL="draft"
+  elif [ "$REVIEW" = "APPROVED" ]; then
+    READY=$((READY + 1))
+    STATUS_LABEL="APPROVED"
+  else
+    CREATED=$((CREATED + 1))
+    STATUS_LABEL="open"
+  fi
+
+  TITLE_SHORT="${TITLE:0:35}"
+  printf "  #%-4s  %-35s  PR#%-5s  %-20s  review:%-18s  stale:%s\n" \
+    "$ISSUE_NUM" "$TITLE_SHORT" "$PR_NUM" "$STATUS_LABEL" "$REVIEW" "$STALE_FLAG"
+done
+
+if [ "$TOTAL" -eq 0 ]; then
+  echo "  No lanes found for milestone: $MILESTONE_SLUG"
+  exit 0
+fi
+
+echo ""
+echo "--- Summary ---"
+echo "  Total:          $TOTAL"
+echo "  Not started:    $CREATED"
+echo "  In progress:    $IN_PROGRESS"
+echo "  Ready (approved): $READY"
+echo "  Merged:         $MERGED_COUNT"
+echo "  Blocked:        $BLOCKED"
+echo "  Stale (>48h):   $STALE_COUNT"
+
+if [ $((BLOCKED + STALE_COUNT)) -gt 0 ]; then
+  echo ""
+  echo "--- Action Required ---"
+  [ "$BLOCKED" -gt 0 ]     && echo "  $BLOCKED lane(s) have CHANGES_REQUESTED — address review feedback"
+  [ "$STALE_COUNT" -gt 0 ] && echo "  $STALE_COUNT lane(s) stale (no commit >48h) — check progress"
+fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,37 +4,59 @@
 
 ## What is this
 
-A meta-plugin to help you manage projects as a solo builder, from idea to shippable features. Claude Code is awesome but pushing it to its limits strains your cognitive resources. Debussy brings a disciplined approach to building fast while keeping a grip on what and how you're building it.
+A meta-plugin to help you manage projects as a solo builder, from idea to
+shippable features. Claude Code is awesome but pushing it to its limits
+strains your cognitive resources. Debussy brings a disciplined approach to
+building fast while keeping a grip on what and how you're building it.
 
 Debussy is a Claude Code plugin organized around four strates:
 
-- **Strategy** (`/debussy:strategy`): Research-first product discovery — map the space, produce structured artifacts under `.debussy/strategy/`, review in a browser UI. Three depth levels: pitch, foundation, full.
-- **Product** (`/debussy:product`): Define the product and shape the roadmap — consumes strategy artifacts, produces product definition and intents under `.debussy/product/`, syncs GitHub Issues. No own research.
-- **Engineering** (`/debussy:engineering`): Manage engineering governance — agent policies, architectural principles, decision records. Three depth levels: lite, standard, full.
-- **Work**: Operational layer — Lanes, Workflow runs (`/debussy:workflow-run`), Feedback inbox (`/debussy:feedback`). Always enabled.
+- **Strategy** (`/debussy:strategy`): Research-first product discovery —
+  map the space, produce structured artifacts under `.debussy/strategy/`,
+  review in a browser UI. Three depth levels: pitch, foundation, full.
+- **Product** (`/debussy:product`): Define the product and shape the
+  roadmap — consumes strategy artifacts, produces product definition and
+  intents under `.debussy/product/`, syncs GitHub Issues. No own research.
+- **Engineering** (`/debussy:engineering`): Manage engineering governance
+  — agent policies, architectural principles, decision records. Three depth
+  levels: lite, standard, full.
+- **Work**: Operational layer — Lanes, Workflow runs
+  (`/debussy:workflow-run`), Feedback inbox (`/debussy:feedback`).
+  Always enabled.
 
 Additional skills:
-- **Init** (`/debussy:init`): Bootstrap a new project — configure strates, scaffold stubs, start the UI.
+
+- **Init** (`/debussy:init`): Bootstrap a new project — configure strates,
+  scaffold stubs, start the UI.
 
 ## Distribution
 
 Inside Claude Code, add the marketplace and install the plugin:
 
-```
+```text
 /plugin marketplace add jcbianic/debussy
 /plugin install debussy@jcbianic-debussy
 ```
 
 ## Structure
 
-```
+```text
 .claude-plugin/    # Plugin metadata (plugin.json, marketplace.json)
-.claude/skills/    # Installed skills (init, strategy, product, engineering, feedback, workflow-run)
+.claude/skills/    # Installed skills (init, strategy, product,
+                   #   engineering, feedback, workflow-run)
 README.md          # Getting started
 CLAUDE.md          # This file
 AGENTS.md          # Agent rules
 ```
 
+## Commit policy
+
+Commit early and often — every coherent change gets its own commit.
+Use `wip(artifacts): ...` for generated/temporary files (specs, plans,
+snapshots) that should be squashed or dropped before merge.
+Full policy: [`.claude/commands/commit.md`](.claude/commands/commit.md)
+
 ## Next Steps
 
-Dogfood `/debussy:strategy` on Debussy itself, then use `/debussy:product` to define the product and shape the roadmap.
+Dogfood `/debussy:strategy` on Debussy itself, then use `/debussy:product`
+to define the product and shape the roadmap.

--- a/README.md
+++ b/README.md
@@ -1,91 +1,73 @@
 # Debussy
 
-A meta-plugin to help you manage projects as a solo builder, from idea to shippable features. Claude Code is awesome but pushing it to its limits strains your cognitive resources. Debussy is here to bring a disciplined approach to building fast while keeping a grip on what and how you're building it.
+Solo building with Claude Code is fast. It's also easy to lose the
+plot — shipping features nobody asked for, accumulating decisions
+nobody wrote down, never pausing to check if the direction still
+makes sense.
 
-## Skills
+Debussy adds structure around the build loop so you can move fast
+without losing the thread.
 
-### Product Skills
+## Strates
 
-**Init** — Bootstrap a new project with Debussy. Starts a browser-based configuration UI where you pick strategy depth (pitch, foundation, full) and optional engineering strate, then scaffolds the documentation hierarchy.
+Four strates cover the loop from discovery to delivery.
 
-```
-/debussy:init
-```
+**Strategy** — Does the research: vision, audience, landscape,
+competitors. Writes to `.debussy/strategy/` and opens a review UI
+so you can push back before anything gets built.
 
-**Strategy** — Research-first product discovery. Investigates the space — vision, problems, audiences, landscape, competitors, allies, feature space, and positioning — then produces structured artifacts under `.debussy/strategy/` with a browser-based review UI. Supports three progressive depth levels.
-
-```
-/debussy:strategy                          # Full run: research -> synthesize -> validate -> write
-/debussy:strategy --refresh competitors    # Re-research one artifact type
-/debussy:strategy --review                 # Open browser review UI for existing artifacts
-```
-
-**Roadmap** — Consume strategy artifacts, produce implementation intents with cross-references (P{N}, A{N}), and sync to GitHub Issues.
-
-```
-/debussy:roadmap                           # Full run: read strategy -> synthesize intents -> sync
-/debussy:roadmap --sync-issues             # Re-sync specs/intents.md -> GitHub Issues
-/debussy:roadmap --update-intent 001       # Update a single intent
+```text
+/debussy:strategy
 ```
 
-### Engineering Skills
+**Product** — Reads the strategy artifacts and turns them into
+intents: a prioritized list of what to build, each synced to a
+GitHub Issue.
 
-**Component Design** — Design or review Vue 3 / Nuxt components using the Orchestration-Presentation principle. Classifies components into tiers (data / orchestration / presentation) and flags violations.
-
-```
-/debussy:component-design <description>
-/debussy:component-design --review <path>
-```
-
-**Component Inventory** — Scan all Vue components and composables, build a persistent health inventory at `.debussy/component-inventory.json`, and review all items for violations.
-
-```
-/debussy:component-inventory               # Full scan and review
-/debussy:component-inventory --browse      # Browse inventory
-/debussy:component-inventory --status      # Show health summary
+```text
+/debussy:product
 ```
 
-**Component Test** — Generate Vitest tests for Vue 3 / Nuxt components and composables. Tier-aware: pure unit tests for composables, component tests for presenters, integration tests for orchestrators.
+**Engineering** — Writes down how the project should be built:
+agent policies, architectural principles, decision records. Three
+levels: lite, standard, full.
 
+```text
+/debussy:engineering
 ```
-/debussy:component-test <path>
-/debussy:component-test --untested         # Find and test untested components
-```
 
-### Utility Skills
+**Work** — Always on. Runs multi-step workflows and collects
+structured feedback via a browser UI.
 
-**Feedback** — Collect structured user feedback via a browser UI. Show a list of items, let users approve/reject/discuss each one, get back structured responses.
-
-```
+```text
+/debussy:workflow-run workflow.yml
 /debussy:feedback request.json
 ```
 
-**Workflow-Run** — Execute multi-step workflows (`.yaml` files) with interactive review gates. Run steps, collect artifacts, present review UI, block on user decisions.
+## Getting started
 
+Run this first:
+
+```text
+/debussy:init
 ```
-/debussy:workflow-run workflow.yml
-/debussy:workflow-run --resume [run_id]
-/debussy:workflow-run --status
-```
+
+Opens a browser UI to pick your strates and depth levels, then
+scaffolds the documentation stubs.
 
 ## Install
 
-Inside Claude Code, add the marketplace and install the plugin:
-
-```
+```text
 /plugin marketplace add jcbianic/debussy
 /plugin install debussy@jcbianic-debussy
 ```
 
-## Source
+## Structure
 
-```
-.claude/skills/init/                # Init skill
-.claude/skills/strategy/            # Strategy skill
-.claude/skills/roadmap/             # Roadmap skill
-.claude/skills/component-design/    # Component Design skill
-.claude/skills/component-inventory/ # Component Inventory skill
-.claude/skills/component-test/      # Component Test skill
-.claude/skills/feedback/            # Feedback skill
-.claude/skills/workflow-run/        # Workflow-Run skill
+```text
+.claude-plugin/    # Plugin metadata (plugin.json, marketplace.json)
+.claude/skills/    # Installed skills
+README.md
+CLAUDE.md
+AGENTS.md
 ```


### PR DESCRIPTION
## Summary

- Add `/release` skill orchestrating the full GitHub milestone release lifecycle (prepare → mature → scaffold → track → close)
- Extract inline `gh` commands into 4 dedicated shell scripts (`list-milestones`, `fetch-issues`, `track-lanes`, `close-checks`)
- Fix jq null-body crash in `fetch-issues.sh` and false-GO on empty lane set in `close-checks.sh`
- Rewrite README to document the four-strate architecture
- Add `wip(artifacts)` commit type to commit policy

## Test plan

- [ ] `/release --prepare <milestone>` scaffolds artifact under `.debussy/releases/`
- [ ] `/release --track <milestone>` outputs lane status table via `track-lanes.sh`
- [ ] `/release --close <milestone>` exits 1 (NO-GO) when unmerged lanes remain
- [ ] `fetch-issues.sh` handles issues with null body without crashing
- [ ] `close-checks.sh` exits 1 when no lanes match the milestone slug

🤖 Generated with [Claude Code](https://claude.com/claude-code)